### PR TITLE
Refactored to reflect the actual (minimal) protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,32 +7,31 @@ This interface layer handles the communication between the Flume Syslog and the 
 
 ## Provides
 
-Charms providing this interface are able to recieve/consume system logs.
+Charms providing this interface are able to receive/consume system logs.
 
 This interface layer will set the following states, as appropriate:
 
-  * `{relation_name}.related`   The relation to a syslog producer has been initialized.
-    If you are providing a service, you can use the following method to pass the port of the service to the
-    other end of the relation:
-      * `send_port(port)`
-
-  * `{relation_name}.available`   The relation to a syslog producer has been established.
-
-For example, let's say that a charm recieves a connection from a syslog producer. 
-The charm providing the log ingestion service should use this interface in the following way:
-
-```python
-@when('syslog.related')
-@when_not('syslog.available')
-def syslog_forward_related(syslog):
-    hookenv.status_set('waiting', 'Waiting for the connection to syslog producer.')
-    syslog.send_port(hookenv.config()['source_port'])
-```
+  * `{relation_name}.joined`   The relation to a syslog producer has been initialized.
 
 
 ## Requires
 
-This part of the relation has not been implemented yet.
+Charms requiring this interface gather logs and forward them to a provider.
+
+This interface layer will set the following states, as appropriate:
+
+  * `{relation_name}.joined`   The relation to a syslog consumer has been initialized.
+    The charm can then access the list of attached consumers via the method:
+
+    * `hosts()`
+
+An example use might be:
+
+```python
+@when('syslog.joined')
+def syslog_joined(syslog):
+    service.register(syslog.hosts())
+```
 
 # Contact Information
 

--- a/provides.py
+++ b/provides.py
@@ -15,28 +15,13 @@ from charms.reactive import hook
 from charms.reactive import scopes
 
 
-class FlumeSyslogProvides(RelationBase):
-    # Every unit connecting will get the same information
+class SyslogProvides(RelationBase):
     scope = scopes.GLOBAL
-    relation_name = 'syslog'
 
-    @hook('{provides:syslog}-relation-{joined}')
+    @hook('{provides:syslog}-relation-joined')
     def joined(self):
-        self.set_state('{relation_name}.related')
+        self.set_state('{relation_name}.joined')
 
-    @hook('{provides:syslog}-relation-{changed}')
-    def changed(self):
-        self.set_state('{relation_name}.available')
-
-    @hook('{provides:syslog}-relation-{departed}')
+    @hook('{provides:syslog}-relation-departed')
     def broken(self):
-        self.remove_state('{relation_name}.available')
-
-    # call this method when passed into methods decorated with
-    # @when('{relation}.related')
-    # to configure the relation data
-    def send_port(self, port):
-        conv = self.conversation()
-        conv.set_remote(data={
-            'port': port,
-        })
+        self.remove_state('{relation_name}.joined')

--- a/requires.py
+++ b/requires.py
@@ -15,30 +15,18 @@ from charms.reactive import hook
 from charms.reactive import scopes
 
 
-# TODO(kt):  Not implemented yet
-class FlumeSyslogRequires(RelationBase):
+class SyslogRequires(RelationBase):
     scope = scopes.UNIT
 
     @hook('{requires:syslog}-relation-joined')
     def joined(self):
         conv = self.conversation()
-        conv.set_state('{relation_name}.connected')
+        conv.set_state('{relation_name}.joined')
 
-    @hook('{requires:syslog}-relation-changed')
-    def changed(self):
-        conv = self.conversation()
-        conv.set_state('{relation_name}.available')
-
-    @hook('{requires:syslog}-relation-{departed}')
+    @hook('{requires:syslog}-relation-departed')
     def departed(self):
         conv = self.conversation()
-        conv.remove_state('{relation_name}.connected')
-        conv.remove_state('{relation_name}.available')
+        conv.remove_state('{relation_name}.joined')
 
-    def get_flume_ip(self):
-        conv = self.conversation()
-        conv.get_remote('private-address')
-
-    def get_flume_port(self):
-        conv = self.conversation()
-        conv.get_remote('port')
+    def hosts(self):
+        return [c.get_remote('private-address') for c in self.conversations()]


### PR DESCRIPTION
No need to handle port if the interface protocol doesn't support it.  Can always add it in later.
